### PR TITLE
Fix segfaulting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(SFMLGame LANGUAGES CXX)
+
+set(SRC_DIR src)
+set(INCLUDE_DIR include)
+set(BUILD_DIR build)
+
+set(CMAKE_BUILD_TYPE Debug)
+
+find_package(SFML COMPONENTS graphics window system)
+
+file(GLOB SOURCES ${SRC_DIR}/*.cpp)
+file(GLOB INCLUDES ${INCLUDE_DIR}/*.hpp)
+
+include_directories(${SFML_INCLUDE} ${INCLUDE_DIR})
+
+add_executable(${PROJECT_NAME} ${SOURCES})
+target_link_directories(${PROJECT_NAME} PRIVATE ${INCLUDES})
+target_link_libraries(${PROJECT_NAME} PRIVATE sfml-main sfml-graphics sfml-window sfml-system)
+
+add_custom_target(debug
+    COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} ${SRCS} -I${SFML_INCLUDE} -I${INCLUDE_DIR} -L${SFML_LIB} -lsfml-main -lsfml-graphics -lsfml-window -lsfml-system -D__DEBUG__ -o ${BUILD_DIR}/debug.exe
+    DEPENDS ${SRCS}
+)
+
+add_custom_target(run_clean
+    COMMAND ${CMAKE_MAKE_PROGRAM} run
+    COMMAND ${CMAKE_MAKE_PROGRAM} clean
+)
+
+add_custom_target(run
+    COMMAND ${PROJECT_NAME}
+    DEPENDS ${PROJECT_NAME}
+)
+
+# add_custom_target(clean
+#     COMMAND PowerShell -Command "Remove-Item -Path ${EXE} -Force"
+# )

--- a/include/Entity.hpp
+++ b/include/Entity.hpp
@@ -1,13 +1,37 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
+#include <string>
+
+enum class EntityEnumType {
+    Player,
+    Enemy,
+    Projectile,
+    None
+};
 
 class Entity {
 protected:
     sf::RectangleShape shape;
+    std::string name;
+    EntityEnumType type;
 public:
     virtual void update(float deltaTime) = 0;
     virtual void render(sf::RenderWindow& window) const = 0;
+    const std::string & getName() const {
+         return this->name;
+    }
+    void setName(const std::string & name) {
+        this->name = name;
+    }
+
+    const EntityEnumType & getType() const {
+        return this->type;
+    }
+
+    void setType(const EntityEnumType & type) {
+        this->type = type;
+    }
 
     sf::Vector2f getPosition() const {
         return shape.getPosition();

--- a/include/EntityManager.hpp
+++ b/include/EntityManager.hpp
@@ -3,22 +3,64 @@
 #include <SFML/Graphics.hpp>
 #include <vector>
 #include <memory>
+#include <iostream>
+#include <string>
 
 #include "Entity.hpp"
+
 
 class EntityManager {
 private:
     std::vector<std::shared_ptr<Entity>> entities;
 
+    int countByType(EntityEnumType type) {
+        int count = 0;
+        for (const auto& entity : entities) {
+            if (entity->getType() == type) {
+                count++;
+            }
+        }
+        return count;
+    }
+
 public:
     template <typename EntityType, typename... Args>
-    std::shared_ptr<EntityType> createEntity(Args&&... args) {
+    std::shared_ptr<EntityType> createEntity(EntityEnumType type, Args&&... args) {
         static_assert(std::is_base_of<Entity, EntityType>::value, "EntityType must be derived from Entity");
 
         std::shared_ptr<EntityType> entity = nullptr;
         entity = std::make_shared<EntityType>(std::forward<Args>(args)...);
+        
+        std::string typestring = "";
+        switch (type) {
+        case EntityEnumType::Player:
+            typestring = "Player";
+            break;
+        case EntityEnumType::Enemy:
+            typestring = "Enemy";
+            break;
+        case EntityEnumType::Projectile:
+            typestring = "Projectile";
+            break;
+        default:
+            typestring = "None";
+            break;
+        }
+        std::string name = typestring + std::to_string(countByType(type));
+        
+        entity->setType(type);
+        entity->setName(name);
         entities.push_back(entity);
         return entity;
+    }
+
+    std::shared_ptr<Entity> getByName(std::string name) {
+        for (const auto& entity : entities) {
+            if (entity->getName() == name) {
+                return entity;
+            }
+        }
+        return nullptr;
     }
 
     void updateEntities(float deltaTime) {

--- a/include/Player.hpp
+++ b/include/Player.hpp
@@ -4,15 +4,11 @@
 
 #include "Entity.hpp"
 #include "EntityManager.hpp"
-#include "Projectile.hpp"
-
-static bool spacebarPressed = false; // Static variable to track spacebar state
 
 class Player : public Entity
 {
 public:
-    Player(EntityManager* entityManager)
-        : entityManager(entityManager)
+    Player()
     {
         shape.setSize(sf::Vector2f(50, 50));
         shape.setFillColor(sf::Color::Red);
@@ -48,27 +44,10 @@ public:
         // Calculate the movement amount based on the movement direction and speed
         sf::Vector2f movementAmount = movementDirection * movementSpeed * deltaTime;
         shape.move(movementAmount);
-
-        if (!spacebarPressed && sf::Keyboard::isKeyPressed(sf::Keyboard::Space))
-        {
-            spacebarPressed = true; // Spacebar pressed, set the flag
-            sf::Vector2f projectilePosition = shape.getPosition() - sf::Vector2f(20, 20);
-            sf::Vector2f projectileDirection(0.0f, -1.0f);
-            float projectileSpeed = 500.0f; 
-
-            auto entity = entityManager->createEntity<Projectile>(projectilePosition, projectileDirection, projectileSpeed);
-        }
-        else if (!sf::Keyboard::isKeyPressed(sf::Keyboard::Space))
-        {
-            spacebarPressed = false; // Spacebar released, reset the flag
-        }
     }
 
     void render(sf::RenderWindow &window) const override
     {
         window.draw(shape);
     }
-
-private:
-    EntityManager* entityManager;
 };

--- a/include/TestGameState.hpp
+++ b/include/TestGameState.hpp
@@ -24,4 +24,5 @@ private:
     sf::Sprite m_background;
 
     std::vector<std::shared_ptr<Entity>> m_enemies;
+    bool spacebarPressed; // Static variable to track spacebar state
 };

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -24,8 +24,6 @@ void Game::run()
         
         m_data->stateManager.processStateChanges();
 
-        m_data->stateManager.processStateChanges();
-
         deltaTime = clock.restart().asSeconds();
 
         m_data->stateManager.getActiveState()->handleEvents();

--- a/src/TestGameState.cpp
+++ b/src/TestGameState.cpp
@@ -1,10 +1,12 @@
 #include "TestGameState.hpp"
-
+#include "Projectile.hpp"
 TestGameState::TestGameState(GameDataRef data) : m_data(data) {}
 
 void TestGameState::init() {
 
-    m_player = m_entityManager.createEntity<Player>(&m_entityManager);
+    spacebarPressed = false;
+
+    m_player = m_entityManager.createEntity<Player>(EntityEnumType::Player);
 
     m_data->camera.setSize(m_data->window.getSize().x, m_data->window.getSize().y);
 
@@ -19,7 +21,21 @@ void TestGameState::handleEvents() {
     if(sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
         // get position of mouse relative to window and view
         const sf::Vector2f mousePosition = m_data->window.mapPixelToCoords(sf::Mouse::getPosition(m_data->window), m_data->camera);
-        m_enemies.push_back(m_entityManager.createEntity<Enemy>(mousePosition.x, mousePosition.y));
+        m_enemies.push_back(m_entityManager.createEntity<Enemy>(EntityEnumType::Enemy, mousePosition.x, mousePosition.y));
+    }
+
+    if (!spacebarPressed && sf::Keyboard::isKeyPressed(sf::Keyboard::Space))
+    {
+        spacebarPressed = true; // Spacebar pressed, set the flag
+        sf::Vector2f projectilePosition = m_entityManager.getByName("Player0")->getPosition() - sf::Vector2f(20, 20);
+        sf::Vector2f projectileDirection(0.0f, -1.0f);
+        float projectileSpeed = 500.0f; 
+
+        auto entity = m_entityManager.createEntity<Projectile>(EntityEnumType::Projectile,projectilePosition, projectileDirection, projectileSpeed);
+    }
+    else if (!sf::Keyboard::isKeyPressed(sf::Keyboard::Space))
+    {
+        spacebarPressed = false; // Spacebar released, reset the flag
     }
 }
 


### PR DESCRIPTION
I saw your post on Reddit and thought I might be able to help a bit.

- I moved the firing code away from the Player and into the State. Personally, I would have preferred all input handling inside the InputManager (since the name implies it Manages Input). This works well enough without it, so I'll leave that up to you.
- I modified the EntityManager, so it will auto-name newly created objects. It does so with an Enum and a helper function, naming each entity <TYPE><COUNT>. This allows you to create a player and then get that player by name "Player0". This is important when we're spawning a new projectile, allowing us to spawn it at the position of "Player0" instead of forcing us to make Player fire the bullet, just so we know where it should spawn.

This should clear up any issues with the shared_ptrs falling out of scope early and accidentally deleting.

- I added a CMakeLists.txt file since I prefer CMake & Ninja over Make. When I'm using Windows, it allows me to just use MingW/MSYS64 and things just 'work'. It's optional, but in case you ever want it, there it is.

Finally, be aware your code for spawning enemies should operate more like the space bar code, with a boolean detecting a mousebuttonpressed and mousebuttonreleased event. Presently, you're only checking if it's down, so by merely clicking, you create a few dozen enemies all in the same spot in just the time that the mouse is 'held down' during the click.  This is evident if you console log out the Entity data on creation.

I could have made more modifications and moved things around, but I would rather not mangle your code too much, and I apologize for what mangling needed to occur.